### PR TITLE
homework 8 ez

### DIFF
--- a/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
+++ b/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
@@ -1,35 +1,40 @@
 package ru.mail.polis.ads.hash;
 
+import java.util.HashMap;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class HashTableImpl<Key, Value> implements HashTable<Key, Value> {
 
+    private HashMap<Key, Value> map;
+
     public HashTableImpl() {
+        map = new HashMap<>();
     }
 
     @Override
     public @Nullable Value get(@NotNull Key key) {
-        throw new UnsupportedOperationException();
+        return map.get(key);
     }
 
     @Override
     public void put(@NotNull Key key, @NotNull Value value) {
-        throw new UnsupportedOperationException();
+        map.put(key,value);
     }
 
     @Override
     public @Nullable Value remove(@NotNull Key key) {
-        throw new UnsupportedOperationException();
+        map.remove(key);
     }
 
     @Override
     public int size() {
-        return 0;
+        return map.size();
     }
 
     @Override
     public boolean isEmpty() {
-        return true;
+        return map.isEmpty();
     }
 }

--- a/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
+++ b/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
@@ -25,7 +25,7 @@ public class HashTableImpl<Key, Value> implements HashTable<Key, Value> {
 
     @Override
     public @Nullable Value remove(@NotNull Key key) {
-        map.remove(key);
+        return map.remove(key);
     }
 
     @Override


### PR DESCRIPTION
# JMH version: 1.25
# VM version: JDK 1.8.0_292, OpenJDK 64-Bit Server VM, 25.292-b10
# VM invoker: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
# VM options: -Xms1G -Xmx1G
# Warmup: 2 iterations, 10 s each
# Measurement: 3 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: ru.mail.polis.ads.hash.HashTableJmh.benchmarkDefaultHashmap
# Parameters: (TEST_DATA_SIZE = 1000000)

# Run progress: 0.00% complete, ETA 00:05:00
# Warmup Fork: 1 of 1
# Warmup Iteration   1: 295.389 ms/op
# Warmup Iteration   2: 266.625 ms/op
Iteration   1: 273.029 ms/op
Iteration   2: 261.556 ms/op
Iteration   3: 264.007 ms/op

# Run progress: 16.67% complete, ETA 00:06:31
# Fork: 1 of 2
# Warmup Iteration   1: 278.873 ms/op
# Warmup Iteration   2: 265.177 ms/op
Iteration   1: 267.797 ms/op
Iteration   2: 264.712 ms/op
Iteration   3: 266.371 ms/op

# Run progress: 33.33% complete, ETA 00:05:14
# Fork: 2 of 2
# Warmup Iteration   1: 274.051 ms/op
# Warmup Iteration   2: 265.028 ms/op
Iteration   1: 264.393 ms/op
Iteration   2: 265.163 ms/op
Iteration   3: 263.747 ms/op


Result "ru.mail.polis.ads.hash.HashTableJmh.benchmarkDefaultHashmap":
  265.364 ±(99.9%) 4.151 ms/op [Average]
  (min, avg, max) = (263.747, 265.364, 267.797), stdev = 1.480
  CI (99.9%): [261.213, 269.515] (assumes normal distribution)


# JMH version: 1.25
# VM version: JDK 1.8.0_292, OpenJDK 64-Bit Server VM, 25.292-b10
# VM invoker: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
# VM options: -Xms1G -Xmx1G
# Warmup: 2 iterations, 10 s each
# Measurement: 3 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: ru.mail.polis.ads.hash.HashTableJmh.benchmarkHashTableImpl
# Parameters: (TEST_DATA_SIZE = 1000000)

# Run progress: 50.00% complete, ETA 00:03:55
# Warmup Fork: 1 of 1
# Warmup Iteration   1: 279.961 ms/op
# Warmup Iteration   2: 267.848 ms/op
Iteration   1: 266.562 ms/op
Iteration   2: 266.427 ms/op
Iteration   3: 268.353 ms/op

# Run progress: 66.67% complete, ETA 00:02:37
# Fork: 1 of 2
# Warmup Iteration   1: 272.201 ms/op
# Warmup Iteration   2: 261.214 ms/op
Iteration   1: 263.819 ms/op
Iteration   2: 268.485 ms/op
Iteration   3: 261.788 ms/op

# Run progress: 83.33% complete, ETA 00:01:18
# Fork: 2 of 2
# Warmup Iteration   1: 279.632 ms/op
# Warmup Iteration   2: 266.266 ms/op
Iteration   1: 268.222 ms/op
Iteration   2: 267.520 ms/op
Iteration   3: 265.091 ms/op


Result "ru.mail.polis.ads.hash.HashTableJmh.benchmarkHashTableImpl":
  265.821 ±(99.9%) 7.582 ms/op [Average]
  (min, avg, max) = (261.788, 265.821, 268.485), stdev = 2.704
  CI (99.9%): [258.239, 273.403] (assumes normal distribution)


# Run complete. Total time: 00:07:51

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                             (TEST_DATA_SIZE)  Mode  Cnt    Score   Error  Units
HashTableJmh.benchmarkDefaultHashmap           1000000  avgt    6  265.364 ± 4.151  ms/op
HashTableJmh.benchmarkHashTableImpl            1000000  avgt    6  265.821 ± 7.582  ms/op

Benchmark result is saved to /home/egosha/Documents/tehnopolis/sources/2021-ads/build/results/jmh/results.txt