### PR TITLE
Homework_8_Kosnitskiy_Alexander

### DIFF
--- a/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
+++ b/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
@@ -1,35 +1,131 @@
 package ru.mail.polis.ads.hash;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class HashTableImpl<Key, Value> implements HashTable<Key, Value> {
+
+    private static class Pair<K, V> {
+        public K key;
+        public V value;
+
+        Pair(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    private static final int[] sizes = {223, 457, 907, 1811, 3643, 7309, 14653, 29231,
+            58657, 117269, 220009, 440023, 880057};
+
+    private byte sizeIndex = 0;
+    private int size = 109;
+
+    private int currSize = 0;
+    @SuppressWarnings("unchecked")
+    private List<Pair<Key, Value>>[] table = new List[size];
 
     public HashTableImpl() {
     }
 
     @Override
     public @Nullable Value get(@NotNull Key key) {
-        throw new UnsupportedOperationException();
+        List<Pair<Key, Value>> pairs = table[getHash(key)];
+        if(pairs == null || pairs.isEmpty()) {
+            return null;
+        }
+        for(Pair<Key, Value> pair : pairs) {
+            if(pair.key.equals(key)) {
+                return pair.value;
+            }
+        }
+        return null;
     }
 
     @Override
     public void put(@NotNull Key key, @NotNull Value value) {
-        throw new UnsupportedOperationException();
+        if(currSize >= size * 0.75) {
+            rehash();
+        }
+        int place = getHash(key);
+        List<Pair<Key, Value>> pairs = table[place];
+        if(pairs == null) {
+            pairs = new LinkedList<>();
+            table[place] = pairs;
+        }
+        for(Pair<Key, Value> pair : pairs) {
+            if(pair.key.equals(key)) {
+                pair.value = value;
+                return;
+            }
+        }
+        currSize++;
+        pairs.add(new Pair<>(key, value));
     }
 
     @Override
     public @Nullable Value remove(@NotNull Key key) {
-        throw new UnsupportedOperationException();
+        List<Pair<Key, Value>> pairs = table[getHash(key)];
+        if(pairs == null) {
+            return null;
+        }
+        for(Pair<Key, Value> pair : pairs) {
+            if(pair.key.equals(key)) {
+                currSize--;
+                Value value = pair.value;
+                pairs.remove(pair);
+                return value;
+            }
+        }
+        return null;
     }
 
     @Override
     public int size() {
-        return 0;
+        return currSize;
     }
 
     @Override
     public boolean isEmpty() {
-        return true;
+        return currSize == 0;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void rehash() {
+        List<Pair<Key, Value>>[] oldTable = table;
+        if(sizeIndex < sizes.length) {
+            table = new List[sizes[sizeIndex]];
+            size = sizes[sizeIndex];
+            sizeIndex++;
+        } else {
+            table = new List[size * 2];
+            size = size * 2;
+        }
+
+        for(List<Pair<Key, Value>> list : oldTable) {
+            if(list != null) {
+                for(Pair<Key, Value> pair : list) {
+                    optimizedPut(pair);
+                }
+            }
+        }
+
+    }
+
+    private void optimizedPut(Pair<Key, Value> pair) {
+        int place = getHash(pair.key);
+        List<Pair<Key, Value>> pairs = table[place];
+        if(pairs == null) {
+            pairs = new LinkedList<>();
+            table[place] = pairs;
+        }
+        pairs.add(pair);
+    }
+
+    private int getHash(Key key) {
+        return Math.abs(key.hashCode() % size);
     }
 }


### PR DESCRIPTION
# JMH version: 1.25
# VM version: JDK 11.0.11, OpenJDK 64-Bit Server VM, 11.0.11+9-Ubuntu-0ubuntu2.20.04
# VM invoker: /usr/lib/jvm/java-11-openjdk-amd64/bin/java
# VM options: -Xms1G -Xmx1G
# Warmup: 2 iterations, 10 s each
# Measurement: 3 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: ru.mail.polis.ads.hash.HashTableJmh.benchmarkDefaultHashmap
# Parameters: (TEST_DATA_SIZE = 1000000)

# Run progress: 0.00% complete, ETA 00:05:00
# Warmup Fork: 1 of 1
# Warmup Iteration   1: 321.244 ms/op
# Warmup Iteration   2: 314.742 ms/op
Iteration   1: 315.126 ms/op
Iteration   2: 308.598 ms/op
Iteration   3: 323.115 ms/op

# Run progress: 16.67% complete, ETA 00:05:54
# Fork: 1 of 2
# Warmup Iteration   1: 291.575 ms/op
# Warmup Iteration   2: 279.155 ms/op
Iteration   1: 271.661 ms/op
Iteration   2: 273.434 ms/op
Iteration   3: 274.694 ms/op

# Run progress: 33.33% complete, ETA 00:04:41
# Fork: 2 of 2
# Warmup Iteration   1: 278.974 ms/op
# Warmup Iteration   2: 270.600 ms/op
Iteration   1: 270.606 ms/op
Iteration   2: 265.800 ms/op
Iteration   3: 266.620 ms/op


Result "ru.mail.polis.ads.hash.HashTableJmh.benchmarkDefaultHashmap":
  270.469 ±(99.9%) 10.087 ms/op [Average]
  (min, avg, max) = (265.800, 270.469, 274.694), stdev = 3.597
  CI (99.9%): [260.382, 280.556] (assumes normal distribution)


# JMH version: 1.25
# VM version: JDK 11.0.11, OpenJDK 64-Bit Server VM, 11.0.11+9-Ubuntu-0ubuntu2.20.04
# VM invoker: /usr/lib/jvm/java-11-openjdk-amd64/bin/java
# VM options: -Xms1G -Xmx1G
# Warmup: 2 iterations, 10 s each
# Measurement: 3 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: ru.mail.polis.ads.hash.HashTableJmh.benchmarkHashTableImpl
# Parameters: (TEST_DATA_SIZE = 1000000)

# Run progress: 50.00% complete, ETA 00:03:30
# Warmup Fork: 1 of 1
# Warmup Iteration   1: 783.918 ms/op
# Warmup Iteration   2: 791.776 ms/op
Iteration   1: 782.029 ms/op
Iteration   2: 789.512 ms/op
Iteration   3: 789.080 ms/op

# Run progress: 66.67% complete, ETA 00:02:20
# Fork: 1 of 2
# Warmup Iteration   1: 777.103 ms/op
# Warmup Iteration   2: 802.220 ms/op
Iteration   1: 800.566 ms/op
Iteration   2: 794.059 ms/op
Iteration   3: 794.411 ms/op

# Run progress: 83.33% complete, ETA 00:01:10
# Fork: 2 of 2
# Warmup Iteration   1: 790.825 ms/op
# Warmup Iteration   2: 788.296 ms/op
Iteration   1: 791.030 ms/op
Iteration   2: 792.635 ms/op
Iteration   3: 791.780 ms/op


Result "ru.mail.polis.ads.hash.HashTableJmh.benchmarkHashTableImpl":
  794.080 ±(99.9%) 9.621 ms/op [Average]
  (min, avg, max) = (791.030, 794.080, 800.566), stdev = 3.431
  CI (99.9%): [784.459, 803.701] (assumes normal distribution)


# Run complete. Total time: 00:07:04

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                             (TEST_DATA_SIZE)  Mode  Cnt    Score    Error  Units
HashTableJmh.benchmarkDefaultHashmap           1000000  avgt    6  270.469 ± 10.087  ms/op
HashTableJmh.benchmarkHashTableImpl            1000000  avgt    6  794.080 ±  9.621  ms/op

Benchmark result is saved to /home/sanerin/GitHub/2021-ads/build/results/jmh/results.txt