### PR TITLE
Homework_8_Trofimov_Artyom

### DIFF
--- a/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
+++ b/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
@@ -34,7 +34,7 @@ public class HashTableImpl<Key, Value> implements HashTable<Key, Value> {
     }
 
     private int hash(Key key) {
-        return Math.abs(key.hashCode() % capacity);//(key.hashCode() % capacity) & 0x7fffffff;
+        return (key.hashCode() & 0x7fffffff) % capacity;
     }
 
     @Override

--- a/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
+++ b/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
@@ -1,35 +1,129 @@
 package ru.mail.polis.ads.hash;
 
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class HashTableImpl<Key, Value> implements HashTable<Key, Value> {
+    private int DEFAULT_CAPACITY = 16;
+    private int capacity = DEFAULT_CAPACITY;
+    private float LOAD_FACTOR = 0.75f;
+    private int size = 0;
+
+    private List<Node>[] data = new List[DEFAULT_CAPACITY];
 
     public HashTableImpl() {
     }
 
     @Override
     public @Nullable Value get(@NotNull Key key) {
-        throw new UnsupportedOperationException();
+        List<Node> nodes = data[hash(key)];
+        if (nodes == null) {
+            return null;
+        }
+
+        for (Node node : nodes) {
+            if (node.key.equals(key)) {
+                return node.value;
+            }
+        }
+        return null;
+    }
+
+    private int hash(Key key) {
+        return Math.abs(key.hashCode() % capacity);//(key.hashCode() % capacity) & 0x7fffffff;
     }
 
     @Override
     public void put(@NotNull Key key, @NotNull Value value) {
-        throw new UnsupportedOperationException();
+        if (size >= capacity * LOAD_FACTOR) {
+            resize();
+        }
+        int hash = hash(key);
+        List<Node> nodes = data[hash];
+        if (nodes == null) {
+            nodes = new LinkedList<>();
+            data[hash] = nodes;
+        }
+        for (Node node : nodes) {
+            if (node.key.equals(key)) {
+                node.value = value;
+                return;
+            }
+        }
+        nodes.add(new Node(key, value));
+        size++;
+    }
+
+    private void resize() {
+        capacity *= 2;
+        List<Node>[] newTable = new List[capacity];
+
+        for (List<Node> list : data) {
+            if (list != null) {
+                for (Node node : list) {
+                    put(newTable, node);
+                }
+            }
+        }
+        data = newTable;
+    }
+
+    private void put(List<Node>[] newTable, Node node) {
+        int hash = hash(node.key);
+        List<Node> nodes = newTable[hash];
+        if (nodes == null) {
+            nodes = new LinkedList<>();
+            newTable[hash] = nodes;
+        }
+        for (Node newNode : nodes) {
+            if (newNode.key.equals(node.key)) {
+                newNode.value = node.value;
+                return;
+            }
+        }
+        nodes.add(node);
     }
 
     @Override
     public @Nullable Value remove(@NotNull Key key) {
-        throw new UnsupportedOperationException();
+        List<Node> nodes = data[hash(key)];
+        if (nodes == null) {
+            return null;
+        }
+
+        for (Iterator<Node> i = nodes.listIterator(); i.hasNext(); ) {
+            Node node = i.next();
+            if (node.key.equals(key)) {
+                size--;
+                Value value = node.value;
+                i.remove();
+                return value;
+            }
+        }
+        return null;
     }
 
     @Override
     public int size() {
-        return 0;
+        return size;
     }
 
     @Override
     public boolean isEmpty() {
-        return true;
+        return size == 0;
+    }
+
+    private class Node {
+        Key key;
+        Value value;
+
+        public Node(Key key, Value value) {
+            this.key = key;
+            this.value = value;
+        }
     }
 }


### PR DESCRIPTION
# JMH version: 1.25
# VM version: JDK 16.0.1, OpenJDK 64-Bit Server VM, 16.0.1+9
# VM invoker: /Users/artem24630/Library/Java/JavaVirtualMachines/azul-16.0.1/Contents/Home/bin/java
# VM options: -Xms1G -Xmx1G
# Warmup: 2 iterations, 10 s each
# Measurement: 3 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: ru.mail.polis.ads.hash.HashTableJmh.benchmarkDefaultHashmap
# Parameters: (TEST_DATA_SIZE = 1000000)

# Run progress: 0,00% complete, ETA 00:05:00
# Warmup Fork: 1 of 1
# Warmup Iteration   1: 167,967 ms/op
# Warmup Iteration   2: 164,577 ms/op
Iteration   1: 163,397 ms/op
Iteration   2: 164,769 ms/op
Iteration   3: 164,987 ms/op

# Run progress: 16,67% complete, ETA 00:06:26
# Fork: 1 of 2
# Warmup Iteration   1: 167,314 ms/op
# Warmup Iteration   2: 165,524 ms/op
Iteration   1: 171,701 ms/op
Iteration   2: 180,562 ms/op
Iteration   3: 185,064 ms/op

# Run progress: 33,33% complete, ETA 00:05:10
# Fork: 2 of 2
# Warmup Iteration   1: 177,666 ms/op
# Warmup Iteration   2: 182,066 ms/op
Iteration   1: 196,860 ms/op
Iteration   2: 182,923 ms/op
Iteration   3: 185,121 ms/op


Result "ru.mail.polis.ads.hash.HashTableJmh.benchmarkDefaultHashmap":
  183,705 ±(99.9%) 22,832 ms/op [Average]
  (min, avg, max) = (171,701, 183,705, 196,860), stdev = 8,142
  CI (99.9%): [160,873, 206,537] (assumes normal distribution)


# JMH version: 1.25
# VM version: JDK 16.0.1, OpenJDK 64-Bit Server VM, 16.0.1+9
# VM invoker: /Users/artem24630/Library/Java/JavaVirtualMachines/azul-16.0.1/Contents/Home/bin/java
# VM options: -Xms1G -Xmx1G
# Warmup: 2 iterations, 10 s each
# Measurement: 3 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: ru.mail.polis.ads.hash.HashTableJmh.benchmarkHashTableImpl
# Parameters: (TEST_DATA_SIZE = 1000000)

# Run progress: 50,00% complete, ETA 00:03:53
# Warmup Fork: 1 of 1
# Warmup Iteration   1: 654,137 ms/op
# Warmup Iteration   2: 588,905 ms/op
Iteration   1: 580,043 ms/op
Iteration   2: 608,135 ms/op
Iteration   3: 576,957 ms/op

# Run progress: 66,67% complete, ETA 00:02:36
# Fork: 1 of 2
# Warmup Iteration   1: 584,819 ms/op
# Warmup Iteration   2: 694,221 ms/op
Iteration   1: 639,856 ms/op
Iteration   2: 681,870 ms/op
Iteration   3: 619,610 ms/op

# Run progress: 83,33% complete, ETA 00:01:18
# Fork: 2 of 2
# Warmup Iteration   1: 563,119 ms/op
# Warmup Iteration   2: 550,255 ms/op
Iteration   1: 584,417 ms/op
Iteration   2: 643,360 ms/op
Iteration   3: 557,974 ms/op


Result "ru.mail.polis.ads.hash.HashTableJmh.benchmarkHashTableImpl":
  621,181 ±(99.9%) 124,609 ms/op [Average]
  (min, avg, max) = (557,974, 621,181, 681,870), stdev = 44,437
  CI (99.9%): [496,572, 745,790] (assumes normal distribution)


# Run complete. Total time: 00:07:50

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                             (TEST_DATA_SIZE)  Mode  Cnt    Score     Error  Units
HashTableJmh.benchmarkDefaultHashmap           1000000  avgt    6  183,705 ±  22,832  ms/op
HashTableJmh.benchmarkHashTableImpl            1000000  avgt    6  621,181 ± 124,609  ms/op

Benchmark result is saved to /Users/artem24630/Desktop/dev/Алгосы/2021-ads/build/results/jmh/results.txt
