### PR TITLE
Homework_8_Dmitry_Kondraev

### DIFF
--- a/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
+++ b/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
@@ -84,6 +84,10 @@ public class HashTableImpl<Key, Value> implements HashTable<Key, Value> {
         return Math.floorMod(hash, capacity());
     }
 
+    /**
+     * Максимальное capacity() == PRIME_CAPACITIES[PRIME_CAPACITIES.length - 1],
+     * Если capacity() достигло максимального значения, то дальше table не расширяется.
+     */
     private Node[] resize() {
         if (capacityIndex >= PRIME_CAPACITIES.length) {
             return table;
@@ -92,6 +96,8 @@ public class HashTableImpl<Key, Value> implements HashTable<Key, Value> {
             capacityIndex++;
         }
         final int newCapacity = PRIME_CAPACITIES[capacityIndex];
+        // необходимо, так как Node === HashTableImpl<Key, Value>.Node,
+        // а массивы с generic типом компонента вне закона (JLS 15.10.1)
         final Node[] newTable = (Node[])new HashTableImpl<?, ?>.Node[newCapacity];
         if (table == null) {
             return newTable;

--- a/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
+++ b/src/main/java/ru/mail/polis/ads/hash/HashTableImpl.java
@@ -5,31 +5,167 @@ import org.jetbrains.annotations.Nullable;
 
 public class HashTableImpl<Key, Value> implements HashTable<Key, Value> {
 
+    private static final int[] PRIME_CAPACITIES = {
+                   53,        97,       193,       389,        769,     1543,     3079,
+                 6151,     12289,     24593,     49157,      98317,   196613,   393241,
+               786433,   1572869,   3145739,   6291469,   12582917, 25165843, 50331653,
+            100663319, 201326611, 402653189, 805306457, 1610612741
+    };
+
+    private static final int DEFAULT_INITIAL_CAPACITY = PRIME_CAPACITIES[0];
+    private static final double LOAD_FACTOR = 0.75;
+
+    int size;
+    Node[] table;
+    int capacityIndex = 0;
+    int capacity = DEFAULT_INITIAL_CAPACITY;
+
     public HashTableImpl() {
     }
 
     @Override
     public @Nullable Value get(@NotNull Key key) {
-        throw new UnsupportedOperationException();
+        if (table == null) {
+            return null;
+        }
+        final int hash = key.hashCode();
+        final Node bucket = bucket(hash);
+        return bucket == null ? null : bucket.get(key);
     }
 
     @Override
     public void put(@NotNull Key key, @NotNull Value value) {
-        throw new UnsupportedOperationException();
+        if (table == null || size >= LOAD_FACTOR * capacity()) {
+            table = resize();
+        }
+        final int hash = key.hashCode();
+        final int index = index(hash);
+        if (table[index] == null) {
+            table[index] = new Node(hash, key, value);
+            size++;
+            return;
+        }
+        table[index].put(hash, key, value);
     }
 
     @Override
     public @Nullable Value remove(@NotNull Key key) {
-        throw new UnsupportedOperationException();
+        if (table == null) {
+            return null;
+        }
+        final int hash = key.hashCode();
+        final int index = index(hash);
+        if (table[index] == null) {
+            return null;
+        }
+        if (table[index].next == null && table[index].key.equals(key)) {
+            Value previous = table[index].value;
+            table[index] = null;
+            size--;
+            return previous;
+        }
+        return table[index].remove(hash, key);
     }
 
     @Override
     public int size() {
-        return 0;
+        return size;
     }
 
     @Override
     public boolean isEmpty() {
-        return true;
+        return size() == 0;
+    }
+
+    private int capacity() {
+        return table != null ? table.length : DEFAULT_INITIAL_CAPACITY;
+    }
+
+    private int index(int hash) {
+        return Math.floorMod(hash, capacity());
+    }
+
+    private Node bucket(int hash) {
+        return table[index(hash)];
+    }
+
+    private Node[] resize() {
+        if (capacityIndex >= PRIME_CAPACITIES.length) {
+            return table;
+        }
+        if (table != null) {
+            capacityIndex++;
+        }
+        final int newCapacity = PRIME_CAPACITIES[capacityIndex];
+        final Node[] newTable = (Node[])new HashTableImpl<?, ?>.Node[newCapacity];
+        if (table == null) {
+            return newTable;
+        }
+        for (Node bucket : table) {
+            for (Node node = bucket, next; node != null; node = next) {
+                next = node.next;
+                int index = Math.floorMod(node.hash, newCapacity);
+                node.next = newTable[index];
+                newTable[index] = node;
+            }
+        }
+        return newTable;
+    }
+
+    private class Node {
+        final Key key;
+        final int hash;
+        Value value;
+        Node next;
+
+        Node(int hash, Key key, Value value, Node next) {
+            this.hash = hash;
+            this.key = key;
+            this.value = value;
+            this.next = next;
+        }
+
+        Node(int hash, Key key, Value value) {
+            this(hash, key, value, null);
+        }
+
+        Node(Key key, Value value) {
+            this(key.hashCode(), key, value, null);
+        }
+
+        Value get(Key key) {
+            Node node = this;
+            while (!(node.next == null || node.hash == key.hashCode() && node.key.equals(key))) {
+                node = node.next;
+            }
+            return node.value;
+        }
+
+        void put(int hash, Key key, Value value) {
+            Node node = this;
+            while (!(node.next == null || node.hash == hash && node.key.equals(key))) {
+                node = node.next;
+            }
+            //node.next == null || node.key.equals(key)
+            if (node.next != null || node.key.equals(key)) {
+                node.value = value;
+                return;
+            }
+            node.next = new Node(hash, key, value);
+            size++;
+        }
+
+        Value remove(int hash, Key key) {
+            Node node = this;
+            while (!(node.next.next == null || node.next.hash == hash && node.next.key.equals(key))) {
+                node = node.next;
+            }
+            if (node.next.next != null || node.next.hash == hash && node.next.key.equals(key)) {
+                size--;
+            }
+            Value previous = node.next.value;
+            node.next = node.next.next;
+            return previous;
+        }
     }
 }


### PR DESCRIPTION
## Результаты прогона тестов

- [human.txt](https://github.com/polis-mail-ru/2021-ads/files/7594906/human.txt)
- [results.txt](https://github.com/polis-mail-ru/2021-ads/files/7594907/results.txt)

<details>
  <summary><code>DefaultHashmap</code> benchmark</summary>

  ```
  # JMH version: 1.25
  # VM version: JDK 11.0.13, OpenJDK 64-Bit Server VM, 11.0.13+8-LTS
  # VM invoker: /home/mariohuq/.jdks/corretto-11.0.13/bin/java
  # VM options: -Xms1G -Xmx1G
  # Warmup: 2 iterations, 10 s each
  # Measurement: 3 iterations, 10 s each
  # Timeout: 10 min per iteration
  # Threads: 1 thread, will synchronize iterations
  # Benchmark mode: Average time, time/op
  # Benchmark: ru.mail.polis.ads.hash.HashTableJmh.benchmarkDefaultHashmap
  # Parameters: (TEST_DATA_SIZE = 1000000)

  # Run progress: 0.00% complete, ETA 00:05:00
  # Warmup Fork: 1 of 1
  # Warmup Iteration   1: 1141.186 ms/op
  # Warmup Iteration   2: 1071.734 ms/op
  Iteration   1: 1111.820 ms/op
  Iteration   2: 1188.745 ms/op
  Iteration   3: 1546.942 ms/op

  # Run progress: 16.67% complete, ETA 00:10:36
  # Fork: 1 of 2
  # Warmup Iteration   1: 1089.039 ms/op
  # Warmup Iteration   2: 1203.282 ms/op
  Iteration   1: 1037.862 ms/op
  Iteration   2: 1024.598 ms/op
  Iteration   3: 993.611 ms/op

  # Run progress: 33.33% complete, ETA 00:08:32
  # Fork: 2 of 2
  # Warmup Iteration   1: 1098.992 ms/op
  # Warmup Iteration   2: 1012.452 ms/op
  Iteration   1: 1102.913 ms/op
  Iteration   2: 1065.054 ms/op
  Iteration   3: 1013.535 ms/op


  Result "ru.mail.polis.ads.hash.HashTableJmh.benchmarkDefaultHashmap":
    1039.596 ±(99.9%) 109.894 ms/op [Average]
    (min, avg, max) = (993.611, 1039.596, 1102.913), stdev = 39.189
    CI (99.9%): [929.702, 1149.489] (assumes normal distribution)
  ```
</details>
<details>
  <summary><code>HashTableImpl</code> benchmark</summary> 

  ```
  # JMH version: 1.25
  # VM version: JDK 11.0.13, OpenJDK 64-Bit Server VM, 11.0.13+8-LTS
  # VM invoker: /home/mariohuq/.jdks/corretto-11.0.13/bin/java
  # VM options: -Xms1G -Xmx1G
  # Warmup: 2 iterations, 10 s each
  # Measurement: 3 iterations, 10 s each
  # Timeout: 10 min per iteration
  # Threads: 1 thread, will synchronize iterations
  # Benchmark mode: Average time, time/op
  # Benchmark: ru.mail.polis.ads.hash.HashTableJmh.benchmarkHashTableImpl
  # Parameters: (TEST_DATA_SIZE = 1000000)

  # Run progress: 50.00% complete, ETA 00:06:21
  # Warmup Fork: 1 of 1
  # Warmup Iteration   1: 1170.685 ms/op
  # Warmup Iteration   2: 1123.428 ms/op
  Iteration   1: 1264.508 ms/op
  Iteration   2: 1192.301 ms/op
  Iteration   3: 1150.940 ms/op

  # Run progress: 66.67% complete, ETA 00:04:13
  # Fork: 1 of 2
  # Warmup Iteration   1: 1168.040 ms/op
  # Warmup Iteration   2: 1105.022 ms/op
  Iteration   1: 1237.602 ms/op
  Iteration   2: 1231.513 ms/op
  Iteration   3: 1159.713 ms/op

  # Run progress: 83.33% complete, ETA 00:02:06
  # Fork: 2 of 2
  # Warmup Iteration   1: 1139.983 ms/op
  # Warmup Iteration   2: 1286.483 ms/op
  Iteration   1: 1145.468 ms/op
  Iteration   2: 1144.555 ms/op
  Iteration   3: 1122.141 ms/op


  Result "ru.mail.polis.ads.hash.HashTableJmh.benchmarkHashTableImpl":
    1173.499 ±(99.9%) 136.952 ms/op [Average]
    (min, avg, max) = (1122.141, 1173.499, 1237.602), stdev = 48.838
    CI (99.9%): [1036.547, 1310.450] (assumes normal distribution)
  ```
</details>

### Run complete. Total time: `00:12:34`

<details>
  <summary>Disclaimer</summary>

  REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
  why the numbers are the way they are. Use profilers (see `-prof`, `-lprof`), design factorial
  experiments, perform baseline and negative tests that provide experimental control, make sure
  the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
  Do not assume the numbers tell you what you want them to tell.

</details>

| Benchmark | (`TEST_DATA_SIZE`) | Mode | Cnt | Score ± Error | Units |
|----------------------------------------|--------------------|------|-----|--------------------|-------|
| `HashTableJmh.benchmarkDefaultHashmap` | 1000000            | avgt | 6   | 1039.596 ± 109.894 | ms/op |
| `HashTableJmh.benchmarkHashTableImpl`  | 1000000            | avgt | 6   | 1173.499 ± 136.952 | ms/op |